### PR TITLE
Add redirect from server root dir to mailman app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 NOTES
+.env
+.history

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:16.04
-MAINTAINER Fer Uria <fauria@gmail.com>
+LABEL maintainer="Stratos Gerakakis<stratosgear@gmail.com>"
 
 ENV URL_FQDN lists.example.com
 ENV EMAIL_FQDN lists.example.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,49 @@
+version: "3"
+
+services:
+  mailman:
+    image: stratosgear/mailman
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    hostname: lists.hypervasis.com
+    env_file:
+      - .env
+    ports:
+      - "49780:80"
+      - "49725:25"
+    volumes:
+      - "mailman_logs_mailman:/var/log/mailman"
+      - "mailman_logs_exim4:/var/log/exim4"
+      - "mailman_logs_apache2:/var/log/apache2"
+      - "mailman_archives:/var/lib/mailman/archives"
+      - "mailman_lists:/var/lib/mailman/lists"
+      - "mailman_tlsd:/etc/exim4/tls.d"
+    networks:
+      - traefik
+    labels:
+      traefik.frontend.rule: Host:lists.hypervasis.com
+      traefik.enable: "true"
+      traefik.backend: mailman
+      traefik.default.protocol: http
+      traefik.port: "80"
+      traefik.docker.network: traefik
+
+networks:
+  traefik:
+    external: true
+
+volumes:
+  mailman_logs_mailman:
+    external: true
+  mailman_logs_exim4:
+    external: true
+  mailman_logs_apache2:
+    external: true
+  mailman_archives:
+    external: true
+  mailman_lists:
+    external: true
+  mailman_tlsd:
+    external: true

--- a/mailman.conf
+++ b/mailman.conf
@@ -23,3 +23,5 @@ Alias /pipermail/ /var/lib/mailman/archives/public/
 # name, to redirect queries to /mailman to the listinfo page (recommended).
 
 RedirectMatch ^/mailman[/]*$ http://lists.example.com/mailman/listinfo
+RedirectMatch ^/[/]*$ http://lists.example.com/mailman/listinfo
+RedirectMatch ^/index.html[/]*$ http://lists.example.com/mailman/listinfo

--- a/run.sh
+++ b/run.sh
@@ -61,6 +61,7 @@ echo 'SMTP_MAX_RCPTS = 500' >> $mailmancfg
 echo 'MAX_DELIVERY_THREADS = 0' >> $mailmancfg
 echo 'SMTPHOST = "localhost"' >> $mailmancfg
 echo 'SMTPPORT = 0' >> $mailmancfg
+echo 'OWNERS_CAN_DELETE_THEIR_OWN_LISTS = Yes' >> $mailmancfg
 
 # remove mm_cfg.pyc, to ensure the new values are picked up
 rm -f "${mailmancfg}c"


### PR DESCRIPTION
Hola,

Not sure if you are still maintaining this project or if you are interested in this simple enhancement that I shamelessly pulled from @AnilRedshift repo.

This basically adds a redirect from the root directory of the lists.example.com default Apache2 page (that looks kinda ugly/confusing) directly to the mailman app directory.