### PR TITLE
Add redirect from server root dir to mailman app

### DIFF
--- a/mailman.conf
+++ b/mailman.conf
@@ -23,3 +23,5 @@ Alias /pipermail/ /var/lib/mailman/archives/public/
 # name, to redirect queries to /mailman to the listinfo page (recommended).
 
 RedirectMatch ^/mailman[/]*$ http://lists.example.com/mailman/listinfo
+RedirectMatch ^/[/]*$ http://lists.example.com/mailman/listinfo
+RedirectMatch ^/index.html[/]*$ http://lists.example.com/mailman/listinfo


### PR DESCRIPTION
Hola,

Not sure if you are still maintaining this project or if you are interested in this simple enhancement that I shamelessly pulled from @AnilRedshift repo.

This basically adds a redirect from the root directory of the lists.example.com default Apache2 page (that looks kinda ugly/confusing) directly to the mailman app directory.